### PR TITLE
Fix install docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This guide will help you set up and start using the Visual Regression Testing tool locally using python.
+This guide will help you set up and start using the Visual Regression Testing tool locally using Python.
 
 ## Prerequisites
 
@@ -31,17 +31,35 @@ This guide will help you set up and start using the Visual Regression Testing to
    pip install -r requirements.txt
    ```
 
-4. **Install Playwright MCP**
+4. **Install the Package in Development Mode**
+
+   ```bash
+   pip install -e .
+   ```
+
+5. **Install Playwright MCP**
 
    ```bash
    npm install -g @playwright/mcp
    ```
 
-5. **Set Up Environment Variables**
+6. **Install Playwright Browsers**
+
+   ```bash
+   npx playwright install
+   ```
+
+7. **Set Up Environment Variables**
    Create a `.env` file in the root directory and add your OpenAI API key:
+
    ```
    OPENAI_API_KEY=your_api_key_here
    ```
+
+   **Optional (for advanced features):**
+
+   - `GITHUB_TOKEN` – for posting PR comments
+   - `BRUNI_TOKEN` and `BRUNI_API_URL` – for Bruni API integration
 
 ## Running the Visual Tests
 
@@ -53,14 +71,18 @@ This guide will help you set up and start using the Visual Regression Testing to
 
 2. **Run the Visual Regression Tests**
 
+   You can run the tests with either of the following commands:
+
    ```bash
+   python -m src.runner.__main__ --base-url <production-url> --pr-url <pull-request-url>
+   # or
    python src/runner/__main__.py --base-url <production-url> --pr-url <pull-request-url>
    ```
 
    Example:
 
    ```bash
-   python src/runner/__main__.py --base-url https://www.brunivisual.com/ --pr-url https://bruni-website-git-changefoo-nevinbuilds.vercel.app/
+   python -m src.runner.__main__ --base-url https://www.brunivisual.com/ --pr-url https://bruni-website-git-changefoo-nevinbuilds.vercel.app/
    ```
 
 ## Understanding the Output

--- a/src/analysis/test_vision.py
+++ b/src/analysis/test_vision.py
@@ -1,0 +1,177 @@
+import pytest
+import json
+import base64
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+from .vision import analyze_images_with_vision
+
+# Sample test data
+SAMPLE_BASE_SCREENSHOT = "test_base.png"
+SAMPLE_PR_SCREENSHOT = "test_pr.png"
+SAMPLE_DIFF_IMAGE = "test_diff.png"
+SAMPLE_BASE_URL = "https://example.com"
+SAMPLE_PREVIEW_URL = "https://preview.example.com"
+SAMPLE_PR_NUMBER = "123"
+SAMPLE_REPOSITORY = "test/repo"
+SAMPLE_USER_ID = "user123"
+
+# Sample sections analysis
+SAMPLE_SECTIONS_ANALYSIS = """
+Header Section: Present at top of page
+Navigation Menu: Present below header
+Hero Section: Present in middle of page
+Footer: Present at bottom of page
+"""
+
+# Sample OpenAI response
+SAMPLE_OPENAI_RESPONSE = {
+    "id": "test-uuid",
+    "url": SAMPLE_BASE_URL,
+    "preview_url": SAMPLE_PREVIEW_URL,
+    "repository": SAMPLE_REPOSITORY,
+    "pr_number": SAMPLE_PR_NUMBER,
+    "timestamp": datetime.utcnow().isoformat(),
+    "status": "pass",
+    "status_enum": "pass",
+    "critical_issues": {
+        "sections": [
+            {
+                "name": "Header Section",
+                "status": "Present",
+                "description": "Header section is present and correctly positioned"
+            }
+        ],
+        "summary": "No critical issues found"
+    },
+    "critical_issues_enum": "none",
+    "structural_analysis": {
+        "section_order": "All sections maintain their original order",
+        "layout": "Layout structure remains consistent",
+        "broken_layouts": "No broken layouts detected"
+    },
+    "visual_changes": {
+        "diff_highlights": ["Minor text updates in header"],
+        "animation_issues": "No animation issues detected",
+        "conclusion": "Changes are within acceptable parameters"
+    },
+    "visual_changes_enum": "minor",
+    "conclusion": {
+        "critical_issues": "No critical issues found",
+        "visual_changes": "Minor visual changes only",
+        "recommendation": "pass",
+        "summary": "Changes are acceptable and do not require review"
+    },
+    "recommendation_enum": "pass",
+    "created_at": datetime.utcnow().isoformat(),
+    "user_id": SAMPLE_USER_ID
+}
+
+@pytest.fixture
+def mock_openai():
+    with patch('openai.OpenAI') as mock:
+        mock_instance = MagicMock()
+        mock.return_value = mock_instance
+        mock_instance.chat.completions.create.return_value.choices = [
+            MagicMock(message=MagicMock(content=json.dumps(SAMPLE_OPENAI_RESPONSE)))
+        ]
+        yield mock_instance
+
+@pytest.fixture
+def mock_file_operations():
+    with patch('builtins.open', MagicMock()) as mock_open:
+        mock_open.return_value.__enter__.return_value.read.return_value = b"test image data"
+        yield mock_open
+
+@pytest.mark.asyncio
+async def test_analyze_images_with_vision_success(mock_openai, mock_file_operations):
+    """Test successful image analysis with all parameters"""
+    result = await analyze_images_with_vision(
+        base_screenshot=SAMPLE_BASE_SCREENSHOT,
+        pr_screenshot=SAMPLE_PR_SCREENSHOT,
+        diff_image=SAMPLE_DIFF_IMAGE,
+        base_url=SAMPLE_BASE_URL,
+        preview_url=SAMPLE_PREVIEW_URL,
+        pr_number=SAMPLE_PR_NUMBER,
+        repository=SAMPLE_REPOSITORY,
+        sections_analysis=SAMPLE_SECTIONS_ANALYSIS,
+        pr_title="Test PR",
+        pr_description="Test description",
+        user_id=SAMPLE_USER_ID
+    )
+
+    # Verify the result structure
+    assert result["status"] == "pass"
+    assert result["status_enum"] == "pass"
+    assert result["critical_issues_enum"] == "none"
+    assert result["visual_changes_enum"] == "minor"
+    assert result["recommendation_enum"] == "pass"
+    assert "sections" in result["critical_issues"]
+    assert len(result["critical_issues"]["sections"]) > 0
+
+@pytest.mark.asyncio
+async def test_analyze_images_with_vision_minimal_params(mock_openai, mock_file_operations):
+    """Test image analysis with minimal required parameters"""
+    result = await analyze_images_with_vision(
+        base_screenshot=SAMPLE_BASE_SCREENSHOT,
+        pr_screenshot=SAMPLE_PR_SCREENSHOT,
+        diff_image=SAMPLE_DIFF_IMAGE,
+        base_url=SAMPLE_BASE_URL,
+        preview_url=SAMPLE_PREVIEW_URL,
+        pr_number=SAMPLE_PR_NUMBER,
+        repository=SAMPLE_REPOSITORY
+    )
+
+    assert result["status"] == "pass"
+    assert result["url"] == SAMPLE_BASE_URL
+    assert result["preview_url"] == SAMPLE_PREVIEW_URL
+    assert result["pr_number"] == SAMPLE_PR_NUMBER
+    assert result["repository"] == SAMPLE_REPOSITORY
+
+@pytest.mark.asyncio
+async def test_analyze_images_with_vision_invalid_json(mock_openai, mock_file_operations):
+    """Test handling of invalid JSON response from OpenAI"""
+    mock_openai.chat.completions.create.return_value.choices = [
+        MagicMock(message=MagicMock(content="invalid json"))
+    ]
+
+    with pytest.raises(Exception) as exc_info:
+        await analyze_images_with_vision(
+            base_screenshot=SAMPLE_BASE_SCREENSHOT,
+            pr_screenshot=SAMPLE_PR_SCREENSHOT,
+            diff_image=SAMPLE_DIFF_IMAGE,
+            base_url=SAMPLE_BASE_URL,
+            preview_url=SAMPLE_PREVIEW_URL,
+            pr_number=SAMPLE_PR_NUMBER,
+            repository=SAMPLE_REPOSITORY
+        )
+
+    assert "Failed to parse AI response as JSON" in str(exc_info.value)
+
+@pytest.mark.asyncio
+async def test_analyze_images_with_vision_invalid_enum(mock_openai, mock_file_operations):
+    """Test handling of invalid enum values in response"""
+    invalid_response = SAMPLE_OPENAI_RESPONSE.copy()
+    invalid_response["status_enum"] = "invalid_status"
+    invalid_response["critical_issues_enum"] = "invalid_issues"
+    invalid_response["visual_changes_enum"] = "invalid_changes"
+    invalid_response["recommendation_enum"] = "invalid_recommendation"
+
+    mock_openai.chat.completions.create.return_value.choices = [
+        MagicMock(message=MagicMock(content=json.dumps(invalid_response)))
+    ]
+
+    result = await analyze_images_with_vision(
+        base_screenshot=SAMPLE_BASE_SCREENSHOT,
+        pr_screenshot=SAMPLE_PR_SCREENSHOT,
+        diff_image=SAMPLE_DIFF_IMAGE,
+        base_url=SAMPLE_BASE_URL,
+        preview_url=SAMPLE_PREVIEW_URL,
+        pr_number=SAMPLE_PR_NUMBER,
+        repository=SAMPLE_REPOSITORY
+    )
+
+    # Verify that invalid enums were corrected to default values
+    assert result["status_enum"] == "warning"
+    assert result["critical_issues_enum"] == "other_issues"
+    assert result["visual_changes_enum"] == "minor"
+    assert result["recommendation_enum"] == "review_required"

--- a/src/runner/__main__.py
+++ b/src/runner/__main__.py
@@ -1,13 +1,16 @@
 import asyncio
 import os
+import sys
 import logging
 import argparse
 import json
 from dotenv import load_dotenv
 import openai
 from openai import RateLimitError
-from agents import Agent, Runner
 import base64
+
+# Add the src directory to the Python path so we can import our modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 # Import from our modules
 from playwright_utils.screenshot import take_screenshot_with_playwright
@@ -22,6 +25,9 @@ from github.pr_metadata import fetch_pr_metadata
 from reporter.reporter import BruniReporter
 from reporter.report_generator import parse_analysis_results
 from github.pr_comments import get_pr_number_from_event
+
+# Import agents after setting up the path
+from agents import Agent, Runner
 
 # ----------------- Setup -------------------
 load_dotenv()


### PR DESCRIPTION
# Fix ModuleNotFoundError and improve local setup documentation

## Problem
Users were encountering `ModuleNotFoundError: No module named 'playwright_utils'` when trying to run the visual regression tests locally.

## Solution
Fixed the import path issue by adding the `src` directory to Python's path in `src/runner/__main__.py`. This allows both `python -m src.runner.__main__` and `python src/runner/__main__.py` to work correctly. Also updated `docs/getting-started.md` with accurate setup instructions including the required `npx playwright install` step and optional environment variables for advanced features.

## Changes
- **Code**: Added `sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))` to resolve module imports
- **Docs**: Added Playwright browser installation step, clarified environment variables, and documented both ways to run tests